### PR TITLE
Update SwaggerDocsConfig.cs

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -304,7 +304,7 @@ namespace Swashbuckle.Application
         public static string DefaultRootUrlResolver(HttpRequestMessage request)
         {
             var scheme = GetHeaderValue(request, "X-Forwarded-Proto") ?? request.RequestUri.Scheme;
-            var host = GetHeaderValue(request, "X-Forwarded-Host") ?? request.RequestUri.Host;
+            var host = (GetHeaderValue(request, "X-Forwarded-Host") ?? request.RequestUri.Host).Split(':')[0];
             var port = GetHeaderValue(request, "X-Forwarded-Port") ?? request.RequestUri.Port.ToString(CultureInfo.InvariantCulture);
             var prefix = GetHeaderValue(request, "X-Forwarded-Prefix") ?? string.Empty;
 


### PR DESCRIPTION
When x-forwarded -Host is ip:prot, var urb = new UriBuilder(scheme, host, int.Parse(port), prefix + virtualPathRoot); will report an error